### PR TITLE
Delete static link

### DIFF
--- a/Walbox/openbox-3/themerc
+++ b/Walbox/openbox-3/themerc
@@ -1,1 +1,0 @@
-/home/edisile/.cache/wal/themerc


### PR DESCRIPTION
# Current behavior
This link gets created by `install.sh`, which will fail if there already is a link.
Then, `walbox` won't work as it points to the creators $HOME
# Fix
Delete the link and let install.sh create it properly.