### PR TITLE
Fix error if themes folder doesn't exist

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,7 @@
 
 config_dir="${XDG_CONFIG_HOME:-$HOME/.config}"
 cache_dir="${XDG_CACHE_DIR:-$HOME/.cache}"
+theme_dir="${XDG_CONFIG_HOME:-$HOME/.themes}"
 
 # Copy themerc template
 mkdir "$config_dir"/wal/templates/ 2> /dev/null
@@ -11,7 +12,8 @@ cp themerc "$config_dir"/wal/templates/themerc
 wal -nqi "$(< "$cache_dir"/wal/wal)"
 
 # Copy theme bitmaps
-cp -r Walbox ~/.themes/Walbox
+mkdir -p "$theme_dir"
+cp -r Walbox  "$theme_dir/Walbox"
 
 # Symlink themerc
-ln --symbolic "$cache_dir/wal/themerc" "$HOME/.themes/Walbox/openbox-3/themerc"
+ln --symbolic "$cache_dir/wal/themerc" "$theme_dir/Walbox/openbox-3/themerc"

--- a/install.sh
+++ b/install.sh
@@ -8,10 +8,10 @@ mkdir "$config_dir"/wal/templates/ 2> /dev/null
 cp themerc "$config_dir"/wal/templates/themerc
 
 # Generate a themerc from current wal colors
-wal -nqi $(cat $cache_dir/wal/wal)
+wal -nqi "$(cat "$cache_dir"/wal/wal)"
 
 # Copy theme bitmaps
 cp -r Walbox ~/.themes/Walbox
 
 # Symlink themerc
-ln --symbolic $cache_dir/wal/themerc $HOME/.themes/Walbox/openbox-3/themerc
+ln --symbolic "$cache_dir/wal/themerc" "$HOME/.themes/Walbox/openbox-3/themerc"

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ mkdir "$config_dir"/wal/templates/ 2> /dev/null
 cp themerc "$config_dir"/wal/templates/themerc
 
 # Generate a themerc from current wal colors
-wal -nqi "$(cat "$cache_dir"/wal/wal)"
+wal -nqi "$(< "$cache_dir"/wal/wal)"
 
 # Copy theme bitmaps
 cp -r Walbox ~/.themes/Walbox


### PR DESCRIPTION
Hello

Got an error in the install because I didn't have a `.themes` folder, so I added a check to create the folder before the cp command. Shellcheck also caught some things, so I fixed them as well.